### PR TITLE
Fix the truncating of OSC commands to 9 characters

### DIFF
--- a/osc.js
+++ b/osc.js
@@ -48,8 +48,7 @@ instance.prototype.config_fields = function () {
 			type: 'textinput',
 			id: 'host',
 			label: 'Target IP',
-			//width: 8, 
-			//commented out as this causes the length ofan OSC command to be truncated at 9 characters...
+			//width: 8, commented out as this causes the length of an OSC command to be truncated at 9 characters...
 			regex: self.REGEX_IP
 		},
 		{

--- a/osc.js
+++ b/osc.js
@@ -48,7 +48,8 @@ instance.prototype.config_fields = function () {
 			type: 'textinput',
 			id: 'host',
 			label: 'Target IP',
-			width: 8,
+			//width: 8, 
+			//commented out as this causes the length ofan OSC command to be truncated at 9 characters...
 			regex: self.REGEX_IP
 		},
 		{


### PR DESCRIPTION
Hi there, 
I have altered the code to prevent OSC messages being truncated at 9 characters. For the moment I have commented out the width that was causing the issues.