### PR TITLE
Added variables to track latest sent and received OSC values

### DIFF
--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -2,7 +2,7 @@
 
 In instaces tab specify the ip and port you want to send. In button actions tab specify the OSC path and value.
 
-**Available commands for OSC Generic**
+**Available actions for OSC Generic:**
 
 - Send message without arguments
 - Send integer
@@ -10,3 +10,36 @@ In instaces tab specify the ip and port you want to send. In button actions tab 
 - Send string
 - Send message with multiple arguments
 - Send boolean (this is not part of OSC standard and may only work with some receivers)
+- Send blob (Base64 & Hex)
+
+**Available feedback for OSC Generic:**
+
+- Listen for OSC messages (Integer)
+- Listen for OSC messages (Float)
+- Listen for OSC messages (Boolean)
+- Listen for OSC messages (Multiple Arguments)
+- Listen for OSC messages (No Arguments)
+
+**Available variables for OSC Generic:**
+- Latest OSC message received timestamp: `$(osc:latest_received_timestamp)`
+- Latest OSC message received: `$(osc:latest_received_raw)`
+- Latest OSC command received: `$(osc:latest_received_command)`
+- Latest OSC message received client (UDP only): `$(osc:latest_received_client)`
+- Latest OSC message received port (UDP only): `$(osc:latest_received_port)`
+- Latest OSC arguments received: `$(osc:latest_received_args)`
+- Latest OSC argument 1 received: `$(osc:latest_received_arg1)`
+- Latest OSC argument 2 received: `$(osc:latest_received_arg2)`
+- Latest OSC argument 3 received: `$(osc:latest_received_arg3)`
+- Latest OSC argument 4 received: `$(osc:latest_received_arg4)`
+- Latest OSC argument 5 received: `$(osc:latest_received_arg5)`
+
+- Latest OSC message sent timestamp: `$(osc:latest_sent_timestamp)`
+- Latest OSC message sent: `$(osc:latest_sent_raw)`
+- Latest OSC command sent: `$(osc:latest_sent_command)`
+- Latest OSC command type sent: `$(osc:latest_sent_type)`
+- Latest OSC arguments sent: `$(osc:latest_sent_args)`
+- Latest OSC argument 1 sent: `$(osc:latest_sent_arg1)`
+- Latest OSC argument 2 sent: `$(osc:latest_sent_arg2)`
+- Latest OSC argument 3 sent: `$(osc:latest_sent_arg3)`
+- Latest OSC argument 4 sent: `$(osc:latest_sent_arg4)`
+- Latest OSC argument 5 sent: `$(osc:latest_sent_arg5)`

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -23,7 +23,7 @@ In instaces tab specify the ip and port you want to send. In button actions tab 
 **Available variables for OSC Generic:**
 - Latest OSC message received timestamp: `$(osc:latest_received_timestamp)`
 - Latest OSC message received: `$(osc:latest_received_raw)`
-- Latest OSC command received: `$(osc:latest_received_command)`
+- Latest OSC path received: `$(osc:latest_received_path)`
 - Latest OSC message received client (UDP only): `$(osc:latest_received_client)`
 - Latest OSC message received port (UDP only): `$(osc:latest_received_port)`
 - Latest OSC arguments received: `$(osc:latest_received_args)`
@@ -32,10 +32,9 @@ In instaces tab specify the ip and port you want to send. In button actions tab 
 - Latest OSC argument 3 received: `$(osc:latest_received_arg3)`
 - Latest OSC argument 4 received: `$(osc:latest_received_arg4)`
 - Latest OSC argument 5 received: `$(osc:latest_received_arg5)`
-
 - Latest OSC message sent timestamp: `$(osc:latest_sent_timestamp)`
 - Latest OSC message sent: `$(osc:latest_sent_raw)`
-- Latest OSC command sent: `$(osc:latest_sent_command)`
+- Latest OSC path sent: `$(osc:latest_sent_path)`
 - Latest OSC command type sent: `$(osc:latest_sent_type)`
 - Latest OSC arguments sent: `$(osc:latest_sent_args)`
 - Latest OSC argument 1 sent: `$(osc:latest_sent_arg1)`

--- a/osc-feedback.js
+++ b/osc-feedback.js
@@ -20,7 +20,7 @@ async function parseOscMessages(root, buffer) {
             buffer = buffer.slice(messageLength);
 
             try {
-                let packet = osc.readPacket(message, {});
+                let packet = osc.readPacket(message, { metadata: true });
                 packets.push(packet);
 
             } catch (err) {
@@ -44,13 +44,32 @@ async function onDataHandler(root, data) {
         const { remainingBuffer, packets } = await parseOscMessages(root, buffer);
         buffer = remainingBuffer;
 
+        root.log('debug', `Raw: ${JSON.stringify(data)}`);
+
         // Handle the parsed packets
         for (const packet of packets) {
             if (packet.address) {
                 root.onDataReceived[packet.address] = packet.args;
-                root.log('debug', `OSC message: ${packet.address}, args: ${JSON.stringify(packet.args)}`);
+                const args_json = JSON.stringify(packet.args);
+                const args_string = packet.args.map(item => item.value).join(" ");
+
+                root.log('debug', `OSC message: ${packet.address}, args: ${args_json}`);
 
                 await root.checkFeedbacks();
+
+                //Update Variables
+                root.setVariableValues({
+                    'latest_received_raw': `${packet.address} ${args_string}`,
+                    'latest_received_command': packet.address,
+                    'latest_received_type': packet.type,
+                    'latest_received_args': (packet.args.length > 0) ? args_json : '',
+                    'latest_received_arg1': (packet.args.length > 0) ? packet.args[0].value : '',
+                    'latest_received_arg2': (packet.args.length > 1) ? packet.args[1].value : '',
+                    'latest_received_arg3': (packet.args.length > 2) ? packet.args[2].value : '',
+                    'latest_received_arg4': (packet.args.length > 3) ? packet.args[3].value : '',
+                    'latest_received_arg5': (packet.args.length > 4) ? packet.args[4].value : '',
+                    'latest_received_timestamp': Date.now()
+                });
 
             } else if (packet.packets) {
                 for (const element of packet.packets) {
@@ -59,6 +78,20 @@ async function onDataHandler(root, data) {
                         root.log('debug', `Bundle element message: ${element.address}, args: ${JSON.stringify(element.args)}`);
                         
                         await root.checkFeedbacks();
+
+                        //Update Variables
+                        root.setVariableValues({
+                            'latest_received_raw': `${packet.address} ${args_json}`,
+                            'latest_received_command': packet.address,
+                            'latest_received_type': packet.type,
+                            'latest_received_args': (packet.args.length > 0) ? args_json : '',
+                            'latest_received_arg1': (packet.args.length > 0) ? packet.args[0].value : '',
+                            'latest_received_arg2': (packet.args.length > 1) ? packet.args[1].value : '',
+                            'latest_received_arg3': (packet.args.length > 2) ? packet.args[2].value : '',
+                            'latest_received_arg4': (packet.args.length > 3) ? packet.args[3].value : '',
+                            'latest_received_arg5': (packet.args.length > 4) ? packet.args[4].value : '',
+                            'latest_received_timestamp': Date.now()
+                        });
                     }
                 }
             }

--- a/osc-feedback.js
+++ b/osc-feedback.js
@@ -60,7 +60,7 @@ async function onDataHandler(root, data) {
                 //Update Variables
                 root.setVariableValues({
                     'latest_received_raw': `${packet.address} ${args_string}`,
-                    'latest_received_command': packet.address,
+                    'latest_received_path': packet.address,
                     'latest_received_type': packet.type,
                     'latest_received_args': (packet.args.length > 0) ? args_json : '',
                     'latest_received_arg1': (packet.args.length > 0) ? packet.args[0].value : '',
@@ -82,7 +82,7 @@ async function onDataHandler(root, data) {
                         //Update Variables
                         root.setVariableValues({
                             'latest_received_raw': `${packet.address} ${args_json}`,
-                            'latest_received_command': packet.address,
+                            'latest_received_path': packet.address,
                             'latest_received_type': packet.type,
                             'latest_received_args': (packet.args.length > 0) ? args_json : '',
                             'latest_received_arg1': (packet.args.length > 0) ? packet.args[0].value : '',

--- a/osc-raw.js
+++ b/osc-raw.js
@@ -96,7 +96,7 @@ class OSCRawClient {
 
 					this.root.setVariableValues({
 						'latest_sent_raw': `${command} ${args_string}`,
-						'latest_sent_command': command,
+						'latest_sent_path': command,
 						'latest_sent_type': (args.length > 0) ? args[0].type : '',
 						'latest_sent_args': (args.length > 0) ? args_json : '',
 						'latest_sent_arg1': (args.length > 0) ? args[0].value : '',

--- a/osc-raw.js
+++ b/osc-raw.js
@@ -90,6 +90,23 @@ class OSCRawClient {
 					this.root.log('warn', errorMessage);
 					reject(new Error(errorMessage));
 				} else {
+					//Update Variables
+					const args_json = JSON.stringify(args);
+					const args_string = args.map(item => item.value).join(" ");
+
+					this.root.setVariableValues({
+						'latest_sent_raw': `${command} ${args_string}`,
+						'latest_sent_command': command,
+						'latest_sent_type': (args.length > 0) ? args[0].type : '',
+						'latest_sent_args': (args.length > 0) ? args_json : '',
+						'latest_sent_arg1': (args.length > 0) ? args[0].value : '',
+						'latest_sent_arg2': (args.length > 1) ? args[1].value : '',
+						'latest_sent_arg3': (args.length > 2) ? args[2].value : '',
+						'latest_sent_arg4': (args.length > 3) ? args[3].value : '',
+						'latest_sent_arg5': (args.length > 4) ? args[4].value : '',
+						'latest_sent_timestamp': Date.now()
+					});
+
 					this.root.log('debug', `Sent command: ${command} with args: ${values.join(', ')}`);
 					resolve();
 				}

--- a/osc-tcp.js
+++ b/osc-tcp.js
@@ -88,6 +88,23 @@ class OSCTCPClient {
 					args: args // Ensure args have correct type and value fields
 				}, this.host, this.port);
 
+				//Update Variables
+				const args_json = JSON.stringify(args);
+				const args_string = args.map(item => item.value).join(" ");
+
+				this.root.setVariableValues({
+					'latest_sent_raw': `${command} ${args_string}`,
+					'latest_sent_command': command,
+					'latest_sent_type': (args.length > 0) ? args[0].type : '',
+					'latest_sent_args': (args.length > 0) ? args_json : '',
+					'latest_sent_arg1': (args.length > 0) ? args[0].value : '',
+					'latest_sent_arg2': (args.length > 1) ? args[1].value : '',
+					'latest_sent_arg3': (args.length > 2) ? args[2].value : '',
+					'latest_sent_arg4': (args.length > 3) ? args[3].value : '',
+					'latest_sent_arg5': (args.length > 4) ? args[4].value : '',
+					'latest_sent_timestamp': Date.now()
+				});
+
 				this.root.log('debug', `Sent command: ${command} with args: ${JSON.stringify(args)}`);
 				resolve();
 			} catch (err) {

--- a/osc-tcp.js
+++ b/osc-tcp.js
@@ -94,7 +94,7 @@ class OSCTCPClient {
 
 				this.root.setVariableValues({
 					'latest_sent_raw': `${command} ${args_string}`,
-					'latest_sent_command': command,
+					'latest_sent_path': command,
 					'latest_sent_type': (args.length > 0) ? args[0].type : '',
 					'latest_sent_args': (args.length > 0) ? args_json : '',
 					'latest_sent_arg1': (args.length > 0) ? args[0].value : '',

--- a/osc-udp.js
+++ b/osc-udp.js
@@ -34,6 +34,11 @@ class OSCUDPClient {
 			this.socket.on('message', (msg, rinfo) => {
 				this.root.log('debug', `Received UDP message from ${rinfo.address}:${rinfo.port}`);
 
+				this.root.setVariableValues({
+                    'latest_received_client': rinfo.address,
+					'latest_received_port': rinfo.port
+                });
+
 				if (this.listen) {
 					onDataHandler(this.root, msg);
 				}
@@ -87,6 +92,24 @@ class OSCUDPClient {
 						reject(new Error(err.message));
 					} else {
 						this.root.log('debug', `Sent command: ${command} with args: ${JSON.stringify(args)}`);
+
+						//Update Variables
+						const args_json = JSON.stringify(args);
+						const args_string = args.map(item => item.value).join(" ");
+
+						this.root.setVariableValues({
+							'latest_sent_raw': `${command} ${args_string}`,
+							'latest_sent_command': command,
+							'latest_sent_type': (args.length > 0) ? args[0].type : '',
+							'latest_sent_args': (args.length > 0) ? args_json : '',
+							'latest_sent_arg1': (args.length > 0) ? args[0].value : '',
+							'latest_sent_arg2': (args.length > 1) ? args[1].value : '',
+							'latest_sent_arg3': (args.length > 2) ? args[2].value : '',
+							'latest_sent_arg4': (args.length > 3) ? args[3].value : '',
+							'latest_sent_arg5': (args.length > 4) ? args[4].value : '',
+							'latest_sent_timestamp': Date.now()
+						});
+
 						resolve();
 					}
 				});

--- a/osc-udp.js
+++ b/osc-udp.js
@@ -99,7 +99,7 @@ class OSCUDPClient {
 
 						this.root.setVariableValues({
 							'latest_sent_raw': `${command} ${args_string}`,
-							'latest_sent_command': command,
+							'latest_sent_path': command,
 							'latest_sent_type': (args.length > 0) ? args[0].type : '',
 							'latest_sent_args': (args.length > 0) ? args_json : '',
 							'latest_sent_arg1': (args.length > 0) ? args[0].value : '',

--- a/osc.js
+++ b/osc.js
@@ -184,7 +184,7 @@ class OSCInstance extends InstanceBase {
 				//Update Variables
 				this.setVariableValues({
 					'latest_sent_raw': `${path} ${args_string}`,
-					'latest_sent_command': path,
+					'latest_sent_path': path,
 					'latest_sent_type': (args.length > 0) ? args[0].type : '',
 					'latest_sent_args': (args.length > 0) ? args_json : '',
 					'latest_sent_arg1': (args.length > 0) ? args[0].value : '',
@@ -800,7 +800,7 @@ class OSCInstance extends InstanceBase {
 		this.setVariableDefinitions([
 			{ variableId: 'latest_received_timestamp', name: 'Latest OSC message received timestamp' },
 			{ variableId: 'latest_received_raw', name: 'Latest OSC message received' },
-			{ variableId: 'latest_received_command', name: 'Latest OSC command received' },
+			{ variableId: 'latest_received_path', name: 'Latest OSC command received' },
 			{ variableId: 'latest_received_client', name: 'Latest OSC message received client (UDP only)' },
 			{ variableId: 'latest_received_port', name: 'Latest OSC message received port (UDP only)' },
 			{ variableId: 'latest_received_args', name: 'Latest OSC arguments received' },
@@ -811,7 +811,7 @@ class OSCInstance extends InstanceBase {
 			{ variableId: 'latest_received_arg5', name: 'Latest OSC argument 5 received' },
 			{ variableId: 'latest_sent_timestamp', name: 'Latest OSC message sent timestamp' },
 			{ variableId: 'latest_sent_raw', name: 'Latest OSC message sent' },
-			{ variableId: 'latest_sent_command', name: 'Latest OSC command sent' },
+			{ variableId: 'latest_sent_path', name: 'Latest OSC command sent' },
 			{ variableId: 'latest_sent_type', name: 'Latest OSC command type sent' },
 			{ variableId: 'latest_sent_args', name: 'Latest OSC arguments sent' },
 			{ variableId: 'latest_sent_arg1', name: 'Latest OSC argument 1 sent' },

--- a/osc.js
+++ b/osc.js
@@ -51,6 +51,7 @@ class OSCInstance extends InstanceBase {
 
 		this.updateActions(); // export actions
 		this.updateFeedbacks(); // export feedback
+		this.updateVariables(); // export variables
 		
 	}
 	// When module gets deleted
@@ -172,18 +173,35 @@ class OSCInstance extends InstanceBase {
 	}
 
 	updateActions() {
-		const sendOscMessage = async (path, args) => {
+		const sendOscMessage = async (path, args, type) => {
+			const args_json = JSON.stringify(args);
+			const args_string = args.map(item => item.value).join(" ");
+
 			this.log('debug', `Sending OSC [${this.config.protocol}] ${this.targetHost}:${this.config.targetPort} ${path}`)
-			this.log('debug', `Sending Args ${JSON.stringify(args)}`)
+			this.log('debug', `Sending Args ${args_json}`)
 
 			if (this.config.protocol === 'udp') {
+				//Update Variables
+				this.setVariableValues({
+					'latest_sent_raw': `${path} ${args_string}`,
+					'latest_sent_command': path,
+					'latest_sent_type': (args.length > 0) ? args[0].type : '',
+					'latest_sent_args': (args.length > 0) ? args_json : '',
+					'latest_sent_arg1': (args.length > 0) ? args[0].value : '',
+					'latest_sent_arg2': (args.length > 1) ? args[1].value : '',
+					'latest_sent_arg3': (args.length > 2) ? args[2].value : '',
+					'latest_sent_arg4': (args.length > 3) ? args[3].value : '',
+					'latest_sent_arg5': (args.length > 4) ? args[4].value : '',
+					'latest_sent_timestamp': Date.now()
+				});
+
 				this.oscSend(this.targetHost, this.config.targetPort, path, args);
 
 			} else {
 				
 				await this.client.sendCommand(path, args)
 				.then(() => {
-					this.log('info', `${this.config.protocol} Command sent successfully. Path: ${path}, Args: ${JSON.stringify(args)}`);
+					this.log('info', `${this.config.protocol} Command sent successfully. Path: ${path}, Args: ${args_json}`);
 				})
 				.catch(err => {
 					this.log('error', `Failed to send ${this.config.protocol} command:`, err.message);
@@ -556,7 +574,7 @@ class OSCInstance extends InstanceBase {
 			
 					if (this.onDataReceived.hasOwnProperty(path)) {
 						const rx_args = this.onDataReceived[path];
-						const receivedValue = parseFloat(rx_args[0]);
+						const receivedValue = parseFloat(rx_args[0].value);
 			
 						const comparisonResult = evaluateComparison(receivedValue, targetValue, comparison);
 			
@@ -618,7 +636,7 @@ class OSCInstance extends InstanceBase {
 			
 					if (this.onDataReceived.hasOwnProperty(path)) {
 						const rx_args = this.onDataReceived[path];
-						const receivedValue = parseFloat(rx_args[0]);
+						const receivedValue = parseFloat(rx_args[0].value);
 			
 						const comparisonResult = evaluateComparison(receivedValue, targetValue, comparison);
 			
@@ -674,7 +692,7 @@ class OSCInstance extends InstanceBase {
 			
 					if (this.onDataReceived.hasOwnProperty(path)) {
 						const rx_args = this.onDataReceived[path];
-						const receivedValue = rx_args[0] === true ? true : false;
+						const receivedValue = rx_args[0].value === true ? true : false;
 			
 						const comparisonResult = evaluateComparison(receivedValue, targetValue, comparison);
 			
@@ -733,7 +751,7 @@ class OSCInstance extends InstanceBase {
 						const rx_args = this.onDataReceived[path];
 						let comparisonResult = (comparison === 'equal');
 						for (let i = 0; i < args.length; i++) {
-							comparisonResult = evaluateComparison(rx_args[i], args[i], comparison);
+							comparisonResult = evaluateComparison(rx_args[i].value, args[i], comparison);
 							if ((comparison === 'equal' && !comparisonResult) || (comparison === 'notequal' && comparisonResult)) {
 								break;
 							}
@@ -776,7 +794,33 @@ class OSCInstance extends InstanceBase {
 				
 			}
 		});
-	}	
+	}
+
+	updateVariables() {
+		this.setVariableDefinitions([
+			{ variableId: 'latest_received_timestamp', name: 'Latest OSC message received timestamp' },
+			{ variableId: 'latest_received_raw', name: 'Latest OSC message received' },
+			{ variableId: 'latest_received_command', name: 'Latest OSC command received' },
+			{ variableId: 'latest_received_client', name: 'Latest OSC message received client (UDP only)' },
+			{ variableId: 'latest_received_port', name: 'Latest OSC message received port (UDP only)' },
+			{ variableId: 'latest_received_args', name: 'Latest OSC arguments received' },
+			{ variableId: 'latest_received_arg1', name: 'Latest OSC argument 1 received' },
+			{ variableId: 'latest_received_arg2', name: 'Latest OSC argument 2 received' },
+			{ variableId: 'latest_received_arg3', name: 'Latest OSC argument 3 received' },
+			{ variableId: 'latest_received_arg4', name: 'Latest OSC argument 4 received' },
+			{ variableId: 'latest_received_arg5', name: 'Latest OSC argument 5 received' },
+			{ variableId: 'latest_sent_timestamp', name: 'Latest OSC message sent timestamp' },
+			{ variableId: 'latest_sent_raw', name: 'Latest OSC message sent' },
+			{ variableId: 'latest_sent_command', name: 'Latest OSC command sent' },
+			{ variableId: 'latest_sent_type', name: 'Latest OSC command type sent' },
+			{ variableId: 'latest_sent_args', name: 'Latest OSC arguments sent' },
+			{ variableId: 'latest_sent_arg1', name: 'Latest OSC argument 1 sent' },
+			{ variableId: 'latest_sent_arg2', name: 'Latest OSC argument 2 sent' },
+			{ variableId: 'latest_sent_arg3', name: 'Latest OSC argument 3 sent' },
+			{ variableId: 'latest_sent_arg4', name: 'Latest OSC argument 4 sent' },
+			{ variableId: 'latest_sent_arg5', name: 'Latest OSC argument 5 sent' },
+		]);
+	}
 	
 	
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "generic-osc",
-	"version": "2.4.4",
+	"version": "2.5.0",
 	"main": "osc.js",
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
This PR aims to implement features discussed in #45:

Added following variables:
- Latest OSC message received timestamp: `$(osc:latest_received_timestamp)`
- Latest OSC message received: `$(osc:latest_received_raw)`
- Latest OSC command received: `$(osc:latest_received_command)`
- Latest OSC message received client (UDP only): `$(osc:latest_received_client)`
- Latest OSC message received port (UDP only): `$(osc:latest_received_port)`
- Latest OSC arguments received: `$(osc:latest_received_args)`
- Latest OSC argument 1 received: `$(osc:latest_received_arg1)`
- Latest OSC argument 2 received: `$(osc:latest_received_arg2)`
- Latest OSC argument 3 received: `$(osc:latest_received_arg3)`
- Latest OSC argument 4 received: `$(osc:latest_received_arg4)`
- Latest OSC argument 5 received: `$(osc:latest_received_arg5)`
- Latest OSC message sent timestamp: `$(osc:latest_sent_timestamp)`
- Latest OSC message sent: `$(osc:latest_sent_raw)`
- Latest OSC command sent: `$(osc:latest_sent_command)`
- Latest OSC command type sent: `$(osc:latest_sent_type)`
- Latest OSC arguments sent: `$(osc:latest_sent_args)`
- Latest OSC argument 1 sent: `$(osc:latest_sent_arg1)`
- Latest OSC argument 2 sent: `$(osc:latest_sent_arg2)`
- Latest OSC argument 3 sent: `$(osc:latest_sent_arg3)`
- Latest OSC argument 4 sent: `$(osc:latest_sent_arg4)`
- Latest OSC argument 5 sent: `$(osc:latest_sent_arg5)`

Also updated internal README for Companion.