### PR TITLE
Add feedback handler for a single string (#56)

### DIFF
--- a/osc.js
+++ b/osc.js
@@ -68,7 +68,7 @@ class OSCInstance extends InstanceBase {
 				this.client = null;
 			})
 			.catch(err => {
-				('error', `${this.config.protocol} close error: ${err.message}`);
+				this.log('error', `${this.config.protocol} close error: ${err.message}`);
 			});
 
 		}

--- a/osc.js
+++ b/osc.js
@@ -731,12 +731,13 @@ class OSCInstance extends InstanceBase {
 					
 					if (this.onDataReceived.hasOwnProperty(path)) {
 						const rx_args = this.onDataReceived[path];
-						if (typeof rx_args[0].value !== 'string')
-						const receivedValue = String(rx_args[0].value);
-						if (typeof receivedValue !== 'string') {
+						
+						if (typeof rx_args[0].value !== 'string') {
   							this.log('warn', `Feedback ${feedback.id} received a non-string value: ${receivedValue}`);
   							return false;
 						}
+						
+						const receivedValue = String(rx_args[0].value);
 						const comparisonResult = evaluateComparison(receivedValue, targetValue, comparison);
 			
 						this.log('debug', `Feedback ${feedback.id} comparison result: ${comparisonResult}`);
@@ -782,11 +783,11 @@ class OSCInstance extends InstanceBase {
 					let argsStr = await context.parseVariablesInString(feedback.options.arguments || '');
 					const comparison = feedback.options.comparison;
 			
-					this.log('debug', `Evaluating feedback ${feedback.id}.`);
+					'debug', `Evaluating feedback ${feedback.id}.`);
 			
 					const { args, error } = parseArguments(argsStr);
 					if (error) {
-						this.log('warn', error);
+						'warn', error);
 						return false;
 					}
 			
@@ -800,10 +801,10 @@ class OSCInstance extends InstanceBase {
 							}
 						}
 			
-						this.log('debug', `Feedback ${feedback.id} comparison result: ${comparisonResult}`);
+						'debug', `Feedback ${feedback.id} comparison result: ${comparisonResult}`);
 						return comparisonResult;
 					} else {
-						this.log('debug', `Feedback ${feedback.id} returned false! Path does not exist yet in dictionary.`);
+						'debug', `Feedback ${feedback.id} returned false! Path does not exist yet in dictionary.`);
 						return false;
 					}
 				}
@@ -823,10 +824,10 @@ class OSCInstance extends InstanceBase {
 				],
 				callback: async (feedback, context) => {
 					const path = await context.parseVariablesInString(feedback.options.path || '');
-					this.log('debug', `Evaluating feedback ${feedback.id}.`);
+					'debug', `Evaluating feedback ${feedback.id}.`);
 	
 					if (this.onDataReceived.hasOwnProperty(path) && this.onDataReceived[path].length > 0) {
-						this.log('debug', `Feedback ${feedback.id} returned true!`);
+						'debug', `Feedback ${feedback.id} returned true!`);
 						delete this.onDataReceived[path]; // Remove the path from the dictionary to create a debounce
 						return true;
 					} else {

--- a/osc.js
+++ b/osc.js
@@ -68,7 +68,7 @@ class OSCInstance extends InstanceBase {
 				this.client = null;
 			})
 			.catch(err => {
-				this.log('error', `${this.config.protocol} close error: ${err.message}`);
+				('error', `${this.config.protocol} close error: ${err.message}`);
 			});
 
 		}
@@ -783,11 +783,11 @@ class OSCInstance extends InstanceBase {
 					let argsStr = await context.parseVariablesInString(feedback.options.arguments || '');
 					const comparison = feedback.options.comparison;
 			
-					'debug', `Evaluating feedback ${feedback.id}.`);
+					this.log('debug', `Evaluating feedback ${feedback.id}.`);
 			
 					const { args, error } = parseArguments(argsStr);
 					if (error) {
-						'warn', error);
+						this.log('warn', error);
 						return false;
 					}
 			
@@ -801,10 +801,10 @@ class OSCInstance extends InstanceBase {
 							}
 						}
 			
-						'debug', `Feedback ${feedback.id} comparison result: ${comparisonResult}`);
+						this.log('debug', `Feedback ${feedback.id} comparison result: ${comparisonResult}`);
 						return comparisonResult;
 					} else {
-						'debug', `Feedback ${feedback.id} returned false! Path does not exist yet in dictionary.`);
+						this.log('debug', `Feedback ${feedback.id} returned false! Path does not exist yet in dictionary.`);
 						return false;
 					}
 				}
@@ -824,10 +824,10 @@ class OSCInstance extends InstanceBase {
 				],
 				callback: async (feedback, context) => {
 					const path = await context.parseVariablesInString(feedback.options.path || '');
-					'debug', `Evaluating feedback ${feedback.id}.`);
+					this.log('debug', `Evaluating feedback ${feedback.id}.`);
 	
 					if (this.onDataReceived.hasOwnProperty(path) && this.onDataReceived[path].length > 0) {
-						'debug', `Feedback ${feedback.id} returned true!`);
+						this.log('debug', `Feedback ${feedback.id} returned true!`);
 						delete this.onDataReceived[path]; // Remove the path from the dictionary to create a debounce
 						return true;
 					} else {

--- a/osc.js
+++ b/osc.js
@@ -692,6 +692,56 @@ class OSCInstance extends InstanceBase {
 					}
 				}
 			},
+			osc_feedback_string: {
+				type: 'boolean',
+				name: 'Listen for OSC messages (String)',
+				description: 'Listen for OSC messages. Requires "Listen for Feedback" option to be enabled in OSC config.',
+				options: [
+					{
+						type: 'textinput',
+						label: 'OSC Path',
+						id: 'path',
+						default: '/osc/path',
+						useVariables: true,
+					},
+					{
+						type: 'textinput',
+						label: 'Arguments',
+						id: 'arguments',
+						default: 'my favorite string',
+						useVariables: true,
+					},
+					{
+						id: 'comparison',
+						type: 'dropdown',
+						label: 'Comparison',
+						choices: [
+							{ id: 'equal', label: '=' },
+							{ id: 'notequal', label: '!=' },
+						],
+						default: 'equal'
+					}
+				],
+				callback: async (feedback, context) => {
+					const path = await context.parseVariablesInString(feedback.options.path || '');
+					const targetValue = await context.parseVariablesInString(feedback.options.arguments || '');
+					const comparison = feedback.options.comparison;
+			
+					this.log('debug', `Evaluating feedback ${feedback.id}.`);
+					
+					if (this.onDataReceived.hasOwnProperty(path)) {
+						const rx_args = this.onDataReceived[path];
+						const receivedValue = String(rx_args[0].value);
+						const comparisonResult = evaluateComparison(receivedValue, targetValue, comparison);
+			
+						this.log('debug', `Feedback ${feedback.id} comparison result: ${comparisonResult}`);
+						return comparisonResult;
+					} else {
+						this.log('debug', `Feedback ${feedback.id} returned false! Path does not exist yet in dictionary.`);
+						return false;
+					}
+				}
+			},
 			osc_feedback_multi: {
 				type: 'boolean',
 				name: 'Listen for OSC messages (Multiple Arguments)',

--- a/osc.js
+++ b/osc.js
@@ -706,7 +706,7 @@ class OSCInstance extends InstanceBase {
 					},
 					{
 						type: 'textinput',
-						label: 'Arguments',
+						label: 'Value',
 						id: 'arguments',
 						default: 'my favorite string',
 						useVariables: true,

--- a/osc.js
+++ b/osc.js
@@ -731,7 +731,12 @@ class OSCInstance extends InstanceBase {
 					
 					if (this.onDataReceived.hasOwnProperty(path)) {
 						const rx_args = this.onDataReceived[path];
+						if (typeof rx_args[0].value !== 'string')
 						const receivedValue = String(rx_args[0].value);
+						if (typeof receivedValue !== 'string') {
+  							this.log('warn', `Feedback ${feedback.id} received a non-string value: ${receivedValue}`);
+  							return false;
+						}
 						const comparisonResult = evaluateComparison(receivedValue, targetValue, comparison);
 			
 						this.log('debug', `Feedback ${feedback.id} comparison result: ${comparisonResult}`);


### PR DESCRIPTION
#56 

Hello,

Hope you don't mind, I took a shot at adding a feedback for a single string. I like this because it mirrors the Action that sends a single string.

I'm sure there are edge cases or situations that I'm not aware of! This is the "most simple" version, and hopefully having this Feedback will show users that they could handle a single string in the same way they could a single integer or a single float. 

Extremely pleased to hear any feedback, and glad to implement it myself if you'd like, or defer to any of your changes.

Cheers,
Will

